### PR TITLE
remove hard coded home directory

### DIFF
--- a/vec2text/experiments.py
+++ b/vec2text/experiments.py
@@ -49,7 +49,9 @@ logger = logging.getLogger(__name__)
 
 # We maintain our own cache because huggingface datasets caching
 # doesn't always work properly.
-DATASET_CACHE_PATH = os.environ.get("VEC2TEXT_CACHE", "/home/wentingz/.cache/inversion")
+DATASET_CACHE_PATH = os.environ.get(
+    "VEC2TEXT_CACHE", os.path.expanduser("~/.cache/inversion")
+)
 
 
 # Noisy compilation from torch.compile

--- a/vec2text/utils/utils.py
+++ b/vec2text/utils/utils.py
@@ -113,7 +113,9 @@ def dataset_map_multi_worker(
         return dataset.map(map_fn, *args, **kwargs)
     datasets.disable_caching()
 
-    cache_path = os.environ.get("VEC2TEXT_CACHE", "/home/wentingz/.cache/inversion")
+    cache_path = os.environ.get(
+        "VEC2TEXT_CACHE", os.path.expanduser("~/.cache/inversion")
+    )
     ds_shard_filepaths = [
         os.path.join(cache_path, f"{dataset._fingerprint}_subshard_{w}.cache")
         for w in range(0, world_size)


### PR DESCRIPTION
Hi @jxmorris12, I noticed this line gives a file not found error with the original implementation. The expanduser function unpacks the "~" to generalize it to any home directory. I'm not sure if you're accepting PRs, feel free to ignore 🙂 