### PR TITLE
Migrate to openai-v1.x.x API

### DIFF
--- a/vec2text/trainers_baseline/fewshot_inversion_trainer.py
+++ b/vec2text/trainers_baseline/fewshot_inversion_trainer.py
@@ -2,14 +2,14 @@ import functools
 from typing import Dict, Iterable, List
 
 import datasets
-from openai import OpenAI
-
-client = OpenAI()
 import torch
 import transformers
+from openai import OpenAI
 from tenacity import retry, stop_after_attempt, wait_fixed
 
 from vec2text.trainers.base import BaseTrainer
+
+client = OpenAI()
 
 
 @retry(wait=wait_fixed(5), stop=stop_after_attempt(10))
@@ -21,12 +21,14 @@ def call_openai_llm(
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": prompt},
     ]
-    return client.chat.completions.create(model=gpt_version,
-    messages=full_prompts,
-    max_tokens=64,
-    temperature=0.0,
-    # stop=["\n"],
-    presence_penalty=0)["choices"][0]["message"]["content"]
+    return client.chat.completions.create(
+        model=gpt_version,
+        messages=full_prompts,
+        max_tokens=64,
+        temperature=0.0,
+        # stop=["\n"],
+        presence_penalty=0,
+    )["choices"][0]["message"]["content"]
 
 
 def make_example_str_input_from_train_row(

--- a/vec2text/utils/utils.py
+++ b/vec2text/utils/utils.py
@@ -178,7 +178,7 @@ def get_embeddings_openai_vanilla_multithread(
     text_list, model="text-embedding-ada-002"
 ) -> list:
     from openai import OpenAI
-    
+
     client = OpenAI()
 
     # print(f"running openai on text_list of length {len(text_list)}, first element '{text_list[0]}'")
@@ -193,9 +193,9 @@ def get_embeddings_openai_vanilla_multithread(
 
     def process_batch(batch):
         text_list_batch = text_list[batch * 128 : (batch + 1) * 128]
-        response = client.embeddings.create(input=text_list_batch,
-        model=model,
-        encoding_format="float")
+        response = client.embeddings.create(
+            input=text_list_batch, model=model, encoding_format="float"
+        )
         return [e["embedding"] for e in response["data"]]
 
     with ThreadPoolExecutor() as executor:
@@ -214,7 +214,7 @@ def get_embeddings_openai_vanilla(text_list, model="text-embedding-ada-002") -> 
     #    api ref: https://platform.openai.com/docs/api-reference/embeddings/create
     # TODO: set up a caching system somehow.
     from openai import OpenAI
-    
+
     client = OpenAI()
 
     # print(f"running openai on text_list of length {len(text_list)}, first element '{text_list[0]}'")
@@ -222,9 +222,9 @@ def get_embeddings_openai_vanilla(text_list, model="text-embedding-ada-002") -> 
     outputs = []
     for batch in range(batches):
         text_list_batch = text_list[batch * 128 : (batch + 1) * 128]
-        response = client.embeddings.create(input=text_list_batch,
-        model=model,
-        encoding_format="float")
+        response = client.embeddings.create(
+            input=text_list_batch, model=model, encoding_format="float"
+        )
         outputs.extend([e["embedding"] for e in response["data"]])
     return outputs
 


### PR DESCRIPTION
Hello,

I was getting an error about the embedding function being deprecated. Since the openai package is not locked to a version, I thought it might be worth migrating vec2text to the new v1.x.x API as well. 

# steps
1. I'm following this guide: https://github.com/openai/openai-python/discussions/742 
```
pip install --upgrade openai 
openai migrate
```

2. Run pre-commit checks
```
pip install isort black flake8 mypy --upgrade
pre-commit run --all
```
There are some failing checks, but I ignored them since they aren't pertinent to the migration changes (I hope that's ok).

Thank you for you consideration!
