### PR TITLE
feat: nomic-embed-text-v1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ tenacity
 tokenizers
 tqdm
 transformers
+einops

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 accelerate
 bert_score
 datasets
+einops
 evaluate
 openai
 optimum
@@ -13,4 +14,3 @@ tenacity
 tokenizers
 tqdm
 transformers
-einops

--- a/vec2text/ds_config.json
+++ b/vec2text/ds_config.json
@@ -1,0 +1,29 @@
+{
+    "flops_profiler": {
+      "enabled": false,
+      "profile_step": 1,
+      "module_depth": -1,
+      "top_modules": 1,
+      "detailed": true,
+      "output_file": null
+      },
+      "train_batch_size": "auto",
+      "gradient_accumulation_steps": "auto",
+      "train_micro_batch_size_per_gpu": "auto",
+      "bf16": {
+          "enabled": "auto"
+      },
+      "gradient_clipping": 1.0,
+      "zero_optimization": {
+          "stage": 2,
+          "offload_param": {
+            "device": "none"
+          },
+          "offload_optimizer": {
+            "device": "none"
+          },
+          "allgather_partitions": true,
+          "allgather_bucket_size": 5e8,
+          "contiguous_gradients": true
+      }
+  }

--- a/vec2text/experiments.py
+++ b/vec2text/experiments.py
@@ -293,11 +293,14 @@ class Experiment(abc.ABC):
                 id=self.kwargs_hash,
                 resume=True,
             )
+            training_args = vars(self.training_args)
+            # deepspeed kwargs are not json serializable
+            training_args = {k: v for k, v in training_args.items() if "deepspeed" not in k}
             wandb.config.update(
                 {
                     **vars(self.model_args),
                     **vars(self.data_args),
-                    **vars(self.training_args),
+                    **training_args,
                 },
                 allow_val_change=True,
             )

--- a/vec2text/experiments.py
+++ b/vec2text/experiments.py
@@ -392,7 +392,7 @@ class Experiment(abc.ABC):
                     "text",
                     self.model_args.max_seq_length,
                     padding=False,
-                    prefix="searh_document"
+                    prefix="search_document"
                     if self.model_args.embedder_model_name
                     == "nomic-ai/nomic-embed-text-v1"
                     else None,

--- a/vec2text/experiments.py
+++ b/vec2text/experiments.py
@@ -392,7 +392,10 @@ class Experiment(abc.ABC):
                     "text",
                     self.model_args.max_seq_length,
                     padding=False,
-                    prefix="searh_document" if self.model_args.embedder_model_name == "nomic-ai/nomic-embed-text-v1" else None
+                    prefix="searh_document"
+                    if self.model_args.embedder_model_name
+                    == "nomic-ai/nomic-embed-text-v1"
+                    else None,
                 ),
                 batched=True,
                 num_proc=get_num_proc(),

--- a/vec2text/experiments.py
+++ b/vec2text/experiments.py
@@ -392,6 +392,7 @@ class Experiment(abc.ABC):
                     "text",
                     self.model_args.max_seq_length,
                     padding=False,
+                    prefix="searh_document" if self.model_args.embedder_model_name == "nomic-ai/nomic-embed-text-v1" else None
                 ),
                 batched=True,
                 num_proc=get_num_proc(),

--- a/vec2text/models/inversion.py
+++ b/vec2text/models/inversion.py
@@ -170,6 +170,7 @@ class InversionModel(transformers.PreTrainedModel):
         self,
         input_ids: torch.Tensor,
         attention_mask: torch.Tensor,
+        token_type_ids: Optional[torch.Tensor] = None,
         # token_type_ids: Optional[torch.Tensor] = None, # not used
     ) -> torch.Tensor:
         embedder = self.embedder
@@ -192,9 +193,10 @@ class InversionModel(transformers.PreTrainedModel):
             )
         elif isinstance(self.embedder, SentenceTransformer):
             # sentence-transformers is kind of really annoying
-            model_output = embedder(
-                {"input_ids": input_ids, "attention_mask": attention_mask}
-            )
+            model_inputs = {"input_ids": input_ids, "attention_mask": attention_mask}
+            if token_type_ids is not None:
+                model_inputs["token_type_ids"] = token_type_ids
+            model_output = embedder(model_inputs)
             embeddings = model_output["sentence_embedding"]
         else:
             model_output = embedder(input_ids=input_ids, attention_mask=attention_mask)

--- a/vec2text/models/inversion.py
+++ b/vec2text/models/inversion.py
@@ -109,6 +109,12 @@ class InversionModel(transformers.PreTrainedModel):
         ######################################################
         self.tokenizer = tokenizer
         self.embedder = embedder
+        if self.embedder_no_grad:
+            for param in self.embedder.parameters():
+                param.requires_grad = False
+
+            self.embedder.eval()
+
         self.embedder_tokenizer = embedder_tokenizer
         self.embedder_model_api = embedder_model_api
         # self.freeze(freeze_strategy=config.freeze_strategy)

--- a/vec2text/models/model_utils.py
+++ b/vec2text/models/model_utils.py
@@ -233,7 +233,9 @@ def load_embedder_and_tokenizer(name: str, torch_dtype: str, **kwargs):
         model = SentenceTransformer(name)
         tokenizer = model.tokenizer
     elif name.startswith("nomic-ai/nomic-embed-text-v1"):
-        model = SentenceTransformer("nomic-ai/nomic-embed-text-v1", trust_remote_code=True)
+        model = SentenceTransformer(
+            "nomic-ai/nomic-embed-text-v1", trust_remote_code=True
+        )
         tokenizer = model.tokenizer
     else:
         print(f"WARNING: Trying to initialize from unknown embedder {name}")

--- a/vec2text/models/model_utils.py
+++ b/vec2text/models/model_utils.py
@@ -24,6 +24,7 @@ EMBEDDER_MODEL_NAMES = [
     "meta-llama/Llama-2-13b-hf",
     "meta-llama/Llama-2-7b-chat-hf",
     "meta-llama/Llama-2-13b-chat-hf",
+    "nomic-ai/nomic-embed-text-v1",
     "gpt2",
     "gpt2-medium",
     "gpt2-large",
@@ -230,6 +231,9 @@ def load_embedder_and_tokenizer(name: str, torch_dtype: str, **kwargs):
         tokenizer.pad_token = tokenizer.eos_token
     elif name.startswith("sentence-transformers/"):
         model = SentenceTransformer(name)
+        tokenizer = model.tokenizer
+    elif name.startswith("nomic-ai/nomic-embed-text-v1"):
+        model = SentenceTransformer("nomic-ai/nomic-embed-text-v1", trust_remote_code=True)
         tokenizer = model.tokenizer
     else:
         print(f"WARNING: Trying to initialize from unknown embedder {name}")

--- a/vec2text/tokenize_data.py
+++ b/vec2text/tokenize_data.py
@@ -12,10 +12,15 @@ def tokenize_function(
     text_column_name: str,
     max_seq_length: int,
     padding: bool = False,
+    prefix: str = None,
 ) -> Callable[[Dict], Dict]:
     def tokenize_function_inner(examples) -> Dict[str, torch.Tensor]:
+        if prefix:
+            texts = [f"{prefix}: {text}" for text in examples[text_column_name]]
+        else:
+            texts = examples[text_column_name]
         output = tokenizer(
-            examples[text_column_name],
+            texts,
             padding=padding,
             truncation=True,
             max_length=max_seq_length,
@@ -56,6 +61,8 @@ def tokenize_function_llama_chat(
     text_column_name,
     max_seq_length,
     padding: bool = False,
+    # no-op for compatibility with other tokenization functions
+    prefix: str = None,
 ) -> Callable[[Dict], Dict]:
     """Use special tokenization for LLAMA chat models."""
 


### PR DESCRIPTION
I had to make two quick changes 

* allowing `token_type_ids` to be passed
* passing a prefix to the tokenization step of the dataset

Let me know if there may be other places I need to pass the prefix. 

Tested code with 
```
torchrun --nproc_per_node=8 run.py --experiment inversion --dataset_name msmarco --per_device_train_batc
h_size 256 --per_device_eval_batch_size 256 --max_seq_length 128 --model_name_or_path t5-base --embedder_model_name nomic-ai/nomic-embed-text-v1 --num_r
epeat_tokens 16 --embedder_no_grad True --learning_rate 0.004 --use_frozen_embeddings_as_input True --num_train_epochs 100 --max_eval_samples 1000 --eva
l_steps 10000 --warmup_steps 10000 --bf16=1
```