### PR TITLE
fix: dtype if using deepspeed

### DIFF
--- a/vec2text/models/inversion.py
+++ b/vec2text/models/inversion.py
@@ -237,6 +237,8 @@ class InversionModel(transformers.PreTrainedModel):
                 attention_mask=embedder_attention_mask,
             )
         if self.embedding_transform_strategy == "repeat":
+            if embeddings.dtype != self.dtype:
+                embeddings = embeddings.to(self.dtype)
             repeated_embeddings = self.embedding_transform(embeddings)
             # linear outputs a big embedding, reshape into a sequence of regular size embeddings.
             embeddings = repeated_embeddings.reshape(


### PR DESCRIPTION
deepspeed sets the weights of the model in mixed precision, need to change precision of embeddings