### PR TITLE
Add mps support

### DIFF
--- a/experiment_scripts/misc/dump_embeddings.py
+++ b/experiment_scripts/misc/dump_embeddings.py
@@ -27,9 +27,9 @@ from models import (
 )
 from tokenize_data import tokenize_function
 from utils import emb
+from vec2text.models.model_utils import device
 
 num_workers = len(os.sched_getaffinity(0))
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
 def load_model_and_tokenizers(

--- a/experiment_scripts/misc/dump_embeddings_binary.py
+++ b/experiment_scripts/misc/dump_embeddings_binary.py
@@ -14,8 +14,7 @@ import torch
 import tqdm
 import transformers
 from data_helpers import NQ_DEV, load_dpr_corpus
-
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+from vec2text.models.model_utils import device
 
 
 def entropy__bits(p: float) -> float:

--- a/experiment_scripts/misc/emb_analysis.py
+++ b/experiment_scripts/misc/emb_analysis.py
@@ -28,7 +28,7 @@ from utils import emb, embed_all_tokens
 
 num_workers = len(os.sched_getaffinity(0))
 max_seq_length = 128
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+from vec2text.models.model_utils import device
 
 
 def reorder_words_except_padding(

--- a/experiment_scripts/misc/sentence_closest_words.py
+++ b/experiment_scripts/misc/sentence_closest_words.py
@@ -11,8 +11,7 @@ import tqdm
 import transformers
 from models import InversionModel, load_embedder_and_tokenizer, load_encoder_decoder
 from utils import embed_all_tokens
-
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+from vec2text.models.model_utils import device
 
 # embedder_model_name = "dpr"
 embedder_model_name = "gtr_base"

--- a/experiment_scripts/misc/sentence_pair_similarity.py
+++ b/experiment_scripts/misc/sentence_pair_similarity.py
@@ -9,7 +9,7 @@ sys.path.append("/home/jxm3/research/retrieval/inversion")
 import torch
 from models import InversionModel, load_embedder_and_tokenizer, load_encoder_decoder
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+from vec2text.models.model_utils import device
 
 
 def main():

--- a/vec2text/analyze_utils.py
+++ b/vec2text/analyze_utils.py
@@ -16,14 +16,8 @@ from vec2text import experiments
 from vec2text.models.config import InversionConfig
 from vec2text.run_args import DataArguments, ModelArguments, TrainingArguments
 from vec2text import run_args as run_args
+from vec2text.models.model_utils import device
 
-device = torch.device(
-    "cuda"
-    if torch.cuda.is_available()
-    else "mps"
-    if torch.backends.mps.is_available()
-    else "cpu"
-)
 transformers.logging.set_verbosity_error()
 
 #############################################################################

--- a/vec2text/api.py
+++ b/vec2text/api.py
@@ -82,13 +82,14 @@ def invert_embeddings(
     corrector: vec2text.trainers.Corrector,
     num_steps: int = None,
     sequence_beam_width: int = 0,
+    max_length: int = 128,
 ) -> List[str]:
     corrector.inversion_trainer.model.eval()
     corrector.model.eval()
 
     gen_kwargs = copy.copy(corrector.gen_kwargs)
     gen_kwargs["min_length"] = 1
-    gen_kwargs["max_length"] = 128
+    gen_kwargs["max_length"] = max_length
 
     if num_steps is None:
         assert (

--- a/vec2text/api_old.py
+++ b/vec2text/api_old.py
@@ -5,7 +5,7 @@ import torch
 import transformers
 
 import vec2text
-from vec2text.models.model_utils import device 
+from vec2text.models.model_utils import device
 
 SUPPORTED_MODELS = ["text-embedding-ada-002", "gtr-base"]
 
@@ -23,17 +23,17 @@ def load_pretrained_corrector(embedder: str) -> vec2text.trainers.Corrector:
     if embedder == "text-embedding-ada-002":
         inversion_model = vec2text.models.InversionModel.from_pretrained(
             "jxm/vec2text__openai_ada002__msmarco__msl128__hypothesizer"
-        ).to(device)
+        )
         model = vec2text.models.CorrectorEncoderModel.from_pretrained(
             "jxm/vec2text__openai_ada002__msmarco__msl128__corrector"
-        ).to(device)
+        )
     elif embedder == "gtr-base":
         inversion_model = vec2text.models.InversionModel.from_pretrained(
             "jxm/gtr__nq__32"
-        ).to(device)
+        )
         model = vec2text.models.CorrectorEncoderModel.from_pretrained(
             "jxm/gtr__nq__32__correct"
-        ).to(device)
+        )
     else:
         raise NotImplementedError(f"embedder `{embedder}` not implemented")
 
@@ -82,11 +82,8 @@ def invert_embeddings(
     corrector: vec2text.trainers.Corrector,
     num_steps: int = None,
     sequence_beam_width: int = 0,
-    max_length: int = 128,
+    max_length: int = 128, #this is not sufficient to add functionality: corrector and hypothesizer also must be modified
 ) -> List[str]:
-    # Ensure embeddings are on the correct device
-    embeddings = embeddings.to(device)
-    
     corrector.inversion_trainer.model.eval()
     corrector.model.eval()
 
@@ -128,9 +125,6 @@ def invert_embeddings_and_return_hypotheses(
     num_steps: int = None,
     sequence_beam_width: int = 0,
 ) -> List[str]:
-    # Ensure embeddings are on the correct device
-    embeddings = embeddings.to(device)
-    
     corrector.inversion_trainer.model.eval()
     corrector.model.eval()
 

--- a/vec2text/models/corrector_encoder_from_logits.py
+++ b/vec2text/models/corrector_encoder_from_logits.py
@@ -7,6 +7,7 @@ import transformers
 from vec2text.models.config import InversionConfig
 
 from .corrector_encoder import CorrectorEncoderModel
+from vec2text.models.model_utils import device
 
 
 class CorrectorEncoderFromLogitsModel(CorrectorEncoderModel):

--- a/vec2text/run_args.py
+++ b/vec2text/run_args.py
@@ -370,7 +370,9 @@ class TrainingArguments(transformers.TrainingArguments):
             ["wandb"] if (self.use_wandb and (self.local_rank <= 0)) else []
         )
         self.dataloader_pin_memory = True
-        num_workers = torch.cuda.device_count()
+        #num_workers = torch.cuda.device_count()
+        num_workers = 10
+
         os.environ["RAYON_RS_NUM_CPUS"] = str(
             num_workers
         )  # Sets threads for hf tokenizers

--- a/vec2text/run_args.py
+++ b/vec2text/run_args.py
@@ -370,8 +370,7 @@ class TrainingArguments(transformers.TrainingArguments):
             ["wandb"] if (self.use_wandb and (self.local_rank <= 0)) else []
         )
         self.dataloader_pin_memory = True
-        #num_workers = torch.cuda.device_count()
-        num_workers = 10
+        num_workers = torch.cuda.device_count()
 
         os.environ["RAYON_RS_NUM_CPUS"] = str(
             num_workers


### PR DESCRIPTION
This is working code, with modifications to put embeddings and models to the mps device if available. Centralized device definition using from vec2text.models.model_utils import device 

HOWEVER it does not improve performance. I still see all computation happening on one core out of 10. 

Any ideas?