### PR TITLE
Windows "support"

### DIFF
--- a/vec2text/experiments.py
+++ b/vec2text/experiments.py
@@ -4,7 +4,12 @@ import hashlib
 import json
 import logging
 import os
-import resource
+
+if platform.system() != "Windows":
+    # Import breaks Windows, so don't import it if we're not on windows.
+    # Surprisingly this doesn't break anything when using the library.
+    import resource
+
 import sys
 from typing import Dict, Optional
 


### PR DESCRIPTION
The `resource` package makes it so Windows cannot use vec2text. Removing the import makes it possible to do so and does not break the library, so this commit makes importing `resource` conditional on not being on Windows.

Feel free to reject this, but having it in here means people don't need to edit the package to use it on Windows :D